### PR TITLE
chore: remove list styling from sidebar

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -22,7 +22,7 @@ window.addEventListener('DOMContentLoaded', async () => {
       }
       if (node.children && node.children.length) {
         const ul = document.createElement('ul');
-        ul.classList.add('ml-4');
+        ul.classList.add('ml-4', 'list-none', 'pl-0');
         if (!isRoot) ul.classList.add('hidden');
         node.children.forEach(child => ul.appendChild(build(child)));
         li.appendChild(ul);
@@ -41,6 +41,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     const nav = document.createElement('nav');
     const ul = document.createElement('ul');
+    ul.classList.add('list-none', 'pl-0');
     ul.appendChild(build(tree, true));
     nav.appendChild(ul);
     sidebar.appendChild(nav);


### PR DESCRIPTION
## Summary
- remove default list bullets by adding Tailwind `list-none pl-0` to sidebar lists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b96b2d53d08325bbdd5e14f58ea1fb