### PR TITLE
Add viewport meta tag to base layout

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>


### PR DESCRIPTION
## Summary
- add responsive viewport meta tag to `templates/layout.html`
- regenerate static pages so the tag propagates to all outputs

## Testing
- `node generate_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a461342c83259abd9df4c75baa2f