### PR TITLE
Add responsive mobile sidebar toggle

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -4,6 +4,12 @@ window.addEventListener('DOMContentLoaded', async () => {
   const depth = segments.length - 1; // exclude current file
   const rootPrefix = '../'.repeat(depth);
   const sidebar = document.getElementById('sidebar');
+  const toggleButton = document.getElementById('sidebarToggle');
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      if (sidebar) sidebar.classList.toggle('hidden');
+    });
+  }
   if (!sidebar) return;
   sidebar.classList.add('pl-0');
   try {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,10 +7,15 @@
 </head>
 <body class="bg-gray-50 text-gray-800">
 <header class="bg-gray-800 text-white p-4">
-  <nav class="container mx-auto flex space-x-4">{{nav}}</nav>
+  <div class="container mx-auto flex items-center">
+    <button id="sidebarToggle" class="md:hidden mr-4">
+      &#9776;
+    </button>
+    <nav class="flex space-x-4">{{nav}}</nav>
+  </div>
 </header>
 <div class="container mx-auto flex">
-  <aside id="sidebar" class="w-64 bg-gray-100 p-4"></aside>
+  <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block"></aside>
   <main class="flex-1 p-4">
     <h1 class="text-3xl font-bold mb-4">{{title}}</h1>
     <p>{{blurb}}</p>


### PR DESCRIPTION
## Summary
- Hide sidebar on small screens and add mobile hamburger button in layout.
- Allow sidebar to toggle visibility via new JavaScript handler.
- Regenerate static pages.

## Testing
- `node generate_pages.js && echo 'pages generated'`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4974c60832593623c8b56124016