### PR TITLE
Highlight current sidebar link

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -24,7 +24,8 @@ window.addEventListener('DOMContentLoaded', async () => {
       li.appendChild(link);
       let isCurrent = new URL(link.href, location.href).pathname === location.pathname;
       if (isCurrent) {
-        link.classList.add('font-bold');
+        link.classList.add('font-bold', 'bg-gray-200', 'rounded', 'border-l-4', 'border-blue-500');
+        link.setAttribute('aria-current', 'page');
         li.dataset.current = 'true';
       }
       if (node.children && node.children.length) {


### PR DESCRIPTION
## Summary
- emphasize current sidebar entry with background, border, and rounded styling
- set `aria-current="page"` for the active page link
- regenerate static pages to pick up script changes

## Testing
- `node generate_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a663ee448325b0b1f8f3d9830b4f