### PR TITLE
Add client-side search field to layout

### DIFF
--- a/search.js
+++ b/search.js
@@ -1,0 +1,47 @@
+// Simple client-side search functionality
+window.addEventListener('DOMContentLoaded', async () => {
+  const searchInput = document.getElementById('search');
+  if (!searchInput) return;
+
+  const segments = location.pathname.split('/').filter(Boolean);
+  const depth = segments.length - 1; // exclude current file
+  const rootPrefix = '../'.repeat(depth);
+
+  let pages = [];
+  try {
+    const res = await fetch(rootPrefix + 'nav.json');
+    const tree = await res.json();
+    function flatten(node) {
+      pages.push({ title: node.title, href: rootPrefix + node.href });
+      if (node.children && node.children.length) node.children.forEach(flatten);
+    }
+    flatten(tree);
+  } catch (err) {
+    console.error('Failed to load search index', err);
+    return;
+  }
+
+  const results = document.createElement('div');
+  results.id = 'search-results';
+  results.classList.add('bg-white', 'text-black', 'mt-2', 'p-2', 'rounded', 'shadow', 'max-h-60', 'overflow-auto');
+  results.classList.add('hidden');
+  searchInput.insertAdjacentElement('afterend', results);
+
+  searchInput.addEventListener('input', () => {
+    const q = searchInput.value.toLowerCase();
+    results.innerHTML = '';
+    if (!q) {
+      results.classList.add('hidden');
+      return;
+    }
+    const matches = pages.filter(p => p.title.toLowerCase().includes(q));
+    matches.forEach(p => {
+      const a = document.createElement('a');
+      a.href = p.href;
+      a.textContent = p.title;
+      a.classList.add('block', 'px-2', 'py-1', 'hover:bg-gray-100');
+      results.appendChild(a);
+    });
+    results.classList.toggle('hidden', matches.length === 0);
+  });
+});

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -13,6 +13,7 @@
       &#9776;
     </button>
     <nav class="flex space-x-4">{{nav}}</nav>
+    <input type="search" id="search" class="ml-auto text-black px-2 py-1 rounded" placeholder="Search..." />
   </div>
 </header>
 <div class="container mx-auto flex">
@@ -26,5 +27,6 @@
 </div>
 <footer class="bg-gray-100 text-center text-sm text-gray-500 py-4 mt-8">© 2024 Web3 Overview</footer>
 <script src="{{rootPrefix}}sidebar.js"></script>
+<script src="{{rootPrefix}}search.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add search input to site header and include new search.js script
- Implement client-side search fetching nav.json and showing matches
- Regenerate static pages

## Testing
- `node generate_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6e480288325a64b9a3a89a12a6f