### PR TITLE
Add breadcrumb navigation to generated pages

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,13 +8,16 @@
 </head>
 <body class="bg-gray-50 text-gray-800">
 <header class="bg-gray-800 text-white p-4">
-  <div class="container mx-auto flex items-center">
-    <button id="sidebarToggle" class="md:hidden mr-4">
-      &#9776;
-    </button>
-    <nav class="flex space-x-4">{{nav}}</nav>
-  </div>
-</header>
+    <div class="container mx-auto flex flex-col md:flex-row md:items-center">
+      <div class="flex items-center mb-2 md:mb-0">
+        <button id="sidebarToggle" class="md:hidden mr-4">
+          &#9776;
+        </button>
+        <nav class="flex space-x-4">{{nav}}</nav>
+      </div>
+      <div class="text-sm text-gray-300">{{breadcrumbs}}</div>
+    </div>
+  </header>
 <div class="container mx-auto flex">
   <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block"></aside>
   <main class="flex-1 p-4">


### PR DESCRIPTION
## Summary
- Compute breadcrumb trails for each page during generation
- Pass breadcrumbs to templates and display in layout header
- Style breadcrumbs with Tailwind classes

## Testing
- `node generate_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6f86fc88325947e4c515c959755