### PR TITLE
feat: add dark mode theme toggle

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,26 +5,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{title}}</title>
   <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-50 text-gray-800">
-<header class="bg-gray-800 text-white p-4">
-  <div class="container mx-auto flex items-center">
-    <button id="sidebarToggle" class="md:hidden mr-4">
-      &#9776;
-    </button>
-    <nav class="flex space-x-4">{{nav}}</nav>
+  </head>
+  <body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+  <header class="bg-gray-800 text-white dark:bg-gray-700 dark:text-gray-100 p-4">
+    <div class="container mx-auto flex items-center">
+      <button id="sidebarToggle" class="md:hidden mr-4">
+        &#9776;
+      </button>
+      <nav class="flex space-x-4">{{nav}}</nav>
+      <button id="themeToggle" class="ml-auto px-2 py-1 bg-gray-700 text-white rounded dark:bg-gray-600 dark:text-gray-100">Toggle Theme</button>
+    </div>
+  </header>
+  <div class="container mx-auto flex">
+    <aside id="sidebar" class="w-64 bg-gray-100 dark:bg-gray-800 p-4 hidden md:block"></aside>
+    <main class="flex-1 p-4">
+      <h1 class="text-3xl font-bold mb-4">{{title}}</h1>
+      <p>{{blurb}}</p>
+      {{links}}
+      {{sections}}
+    </main>
   </div>
-</header>
-<div class="container mx-auto flex">
-  <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block"></aside>
-  <main class="flex-1 p-4">
-    <h1 class="text-3xl font-bold mb-4">{{title}}</h1>
-    <p>{{blurb}}</p>
-    {{links}}
-    {{sections}}
-  </main>
-</div>
-<footer class="bg-gray-100 text-center text-sm text-gray-500 py-4 mt-8">© 2024 Web3 Overview</footer>
-<script src="{{rootPrefix}}sidebar.js"></script>
-</body>
-</html>
+  <footer class="bg-gray-100 dark:bg-gray-800 text-center text-sm text-gray-500 dark:text-gray-400 py-4 mt-8">© 2024 Web3 Overview</footer>
+  <script src="{{rootPrefix}}theme.js"></script>
+  <script src="{{rootPrefix}}sidebar.js"></script>
+  </body>
+  </html>

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,30 @@
+// Handles light/dark theme switching and persistence
+(function () {
+  const STORAGE_KEY = 'theme';
+  const body = document.body;
+
+  function apply(theme) {
+    if (theme === 'dark') {
+      body.classList.add('dark');
+    } else {
+      body.classList.remove('dark');
+    }
+  }
+
+  // Apply saved preference on load
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    apply(saved);
+  }
+
+  // Attach listener once DOM is ready
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('themeToggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+      const isDark = body.classList.toggle('dark');
+      localStorage.setItem(STORAGE_KEY, isDark ? 'dark' : 'light');
+    });
+  });
+})();
+


### PR DESCRIPTION
## Summary
- add theme toggle button and dark mode styling
- introduce theme.js to persist user preference and toggle `dark` class
- wire new script into layout and include dark Tailwind variants

## Testing
- `node generate_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6ff2e4c8325a03a52226fde37a2