### PR TITLE
Add title and spacing to top bar

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,13 +8,11 @@
 </head>
 <body class="bg-gray-50 text-gray-800">
   <header class="bg-gray-800 text-white p-4">
-    <div class="container mx-auto flex flex-col md:flex-row md:items-center">
-      <div class="flex items-center mb-2 md:mb-0">
-        <button id="sidebarToggle" class="md:hidden mr-4">
-          &#9776;
-        </button>
-        <nav class="flex space-x-4">{{nav}}</nav>
-      </div>
+    <div class="container mx-auto flex flex-wrap items-center gap-4">
+      <button id="sidebarToggle" class="md:hidden">&#9776;</button>
+      <h1 class="text-lg font-semibold">Web 3.0 - Quick Tour</h1>
+      <nav class="flex space-x-4">{{nav}}</nav>
+      <input id="search" type="text" placeholder="Search..." class="text-black px-2 py-1 rounded" />
       <div class="text-sm text-gray-300">{{breadcrumbs}}</div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- show site title "Web 3.0 - Quick Tour" in header
- add search input and space elements in top bar for clearer layout

## Testing
- `node generate_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac82a43883258744ed3864bc86ff