### PR TITLE
Refine top banner layout

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,12 +8,16 @@
 </head>
 <body class="bg-gray-50 text-gray-800">
   <header class="bg-gray-800 text-white p-4">
-    <div class="container mx-auto flex flex-wrap items-center gap-4">
-      <button id="sidebarToggle" class="md:hidden">&#9776;</button>
-      <h1 class="text-lg font-semibold">Web 3.0 - Quick Tour</h1>
-      <nav class="flex space-x-4">{{nav}}</nav>
-      <input id="search" type="text" placeholder="Search..." class="text-black px-2 py-1 rounded" />
-      <div class="text-sm text-gray-300">{{breadcrumbs}}</div>
+    <div class="container mx-auto">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-4">
+          <button id="sidebarToggle" class="md:hidden">&#9776;</button>
+          <nav class="flex space-x-4">{{nav}}</nav>
+        </div>
+        <input id="search" type="text" placeholder="Search..." class="text-black px-2 py-1 rounded" />
+      </div>
+      <h1 class="text-xl font-semibold mt-2">Web 3.0 - Quick Tour</h1>
+      <div class="text-sm text-gray-300 mt-1">{{breadcrumbs}}</div>
     </div>
   </header>
 <div class="container mx-auto flex">


### PR DESCRIPTION
## Summary
- Rework header banner to split navigation and title into separate rows for clearer hierarchy
- Left-align Home/Back buttons, right-align search bar, and enlarge banner title with dedicated line
- Move breadcrumbs below the title for cleaner layout

## Testing
- `node generate_pages.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba3edb35f08325a6b6607e02eff0f9