### PR TITLE
Support YouTube panels in generated pages

### DIFF
--- a/content/curatedL4.json
+++ b/content/curatedL4.json
@@ -2,6 +2,7 @@
   "Decentralization": {
     "Node Diversity": {
       "blurb": "Many independent operators reduce capture risk.",
+      "videoId": "dQw4w9WgXcQ",
       "sections": {
         "why": "Diverse node operators make censorship or coordinated failure less likely.",
         "key": [

--- a/content/pages.json
+++ b/content/pages.json
@@ -1,6 +1,7 @@
 {
   "title": "Web3",
   "blurb": "A user-empowering internet that encodes trust and value natively using cryptography, blockchains, and open protocols.",
+  "videoId": "M7lc1UVf-VE",
   "children": [
     {
       "title": "Foundations & Principles",
@@ -9,6 +10,7 @@
         {
           "title": "Decentralization",
           "blurb": "Shift of control from single authorities to distributed participants.",
+          "videoId": "hYip_Vuv8J0",
           "children": []
         },
         {

--- a/generate_pages.js
+++ b/generate_pages.js
@@ -17,6 +17,15 @@ function render(values) {
   return html;
 }
 
+function videoHtml(videoId) {
+  if (!videoId) return '';
+  return `<aside class="w-full md:w-80 md:ml-4 mt-4 md:mt-0 shrink-0">
+    <a href="https://youtu.be/${videoId}" target="_blank">
+      <img src="https://img.youtube.com/vi/${videoId}/hqdefault.jpg" alt="YouTube thumbnail" />
+    </a>
+  </aside>`;
+}
+
 function sectionHtml(sections = {}) {
   let html = '';
   if (sections.why) {
@@ -41,7 +50,7 @@ function sectionHtml(sections = {}) {
   return html;
 }
 
-function pageTemplate(title, blurb, linksHtml, depth, backHref, sections = {}, breadcrumbs = '') {
+function pageTemplate(title, blurb, linksHtml, depth, backHref, sections = {}, breadcrumbs = '', videoId = '') {
   const homeHref = depth > 0 ? `${'../'.repeat(depth)}index.html` : 'index.html';
   const rootPrefix = depth > 0 ? '../'.repeat(depth) : '';
   const navLinks = [`<a href="${homeHref}" class="text-blue-200 hover:text-white">Home</a>`];
@@ -53,7 +62,8 @@ function pageTemplate(title, blurb, linksHtml, depth, backHref, sections = {}, b
     sections: sectionHtml(sections),
     nav: navLinks.join('<span>|</span>'),
     rootPrefix,
-    breadcrumbs
+    breadcrumbs,
+    video: videoHtml(videoId)
   });
 }
 
@@ -88,11 +98,11 @@ function generate(node, dir, depth, backHref, ancestors = []) {
   if (l4) {
     links += '<ul>\n';
     if (Array.isArray(l4)) {
-      l4.forEach(([title, blurb]) => {
+      l4.forEach(([title, blurb, videoId]) => {
         const slug = slugify(title);
         links += `  <li><a href="${slug}.html">${title}</a></li>\n`;
         const l4Breadcrumbs = breadcrumbsArr.concat(title).join(' / ');
-        const l4Html = pageTemplate(title, blurb, '', depth, 'index.html', defaultSections(title, blurb), l4Breadcrumbs);
+        const l4Html = pageTemplate(title, blurb, '', depth, 'index.html', defaultSections(title, blurb), l4Breadcrumbs, videoId);
         fs.writeFileSync(path.join(dir, `${slug}.html`), l4Html);
       });
     } else {
@@ -101,13 +111,13 @@ function generate(node, dir, depth, backHref, ancestors = []) {
         links += `  <li><a href="${slug}.html">${title}</a></li>\n`;
         const sections = entry.sections || defaultSections(title, entry.blurb);
         const l4Breadcrumbs = breadcrumbsArr.concat(title).join(' / ');
-        const l4Html = pageTemplate(title, entry.blurb, '', depth, 'index.html', sections, l4Breadcrumbs);
+        const l4Html = pageTemplate(title, entry.blurb, '', depth, 'index.html', sections, l4Breadcrumbs, entry.videoId);
         fs.writeFileSync(path.join(dir, `${slug}.html`), l4Html);
       });
     }
     links += '</ul>\n';
   }
-  const html = pageTemplate(node.title, node.blurb, links, depth, backHref, {}, breadcrumbs);
+  const html = pageTemplate(node.title, node.blurb, links, depth, backHref, {}, breadcrumbs, node.videoId);
   fs.writeFileSync(path.join(dir, 'index.html'), html);
   if (node.children && node.children.length) {
     node.children.forEach(child => {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -22,12 +22,17 @@
   </header>
 <div class="container mx-auto flex">
   <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block"></aside>
-  <main class="flex-1 p-4">
-    <h1 class="text-3xl font-bold mb-4">{{title}}</h1>
-    <p>{{blurb}}</p>
-    {{links}}
-    {{sections}}
-  </main>
+  <div class="flex-1 p-4">
+    <div class="flex flex-col md:flex-row">
+      <main class="flex-1">
+        <h1 class="text-3xl font-bold mb-4">{{title}}</h1>
+        <p>{{blurb}}</p>
+        {{links}}
+        {{sections}}
+      </main>
+      {{video}}
+    </div>
+  </div>
 </div>
 <footer class="bg-gray-100 text-center text-sm text-gray-500 py-4 mt-8">© 2024 Web3 Overview</footer>
 <script src="{{rootPrefix}}sidebar.js"></script>


### PR DESCRIPTION
## Summary
- allow `videoId` for topics in `pages.json` and `curatedL4.json`
- inject a responsive video thumbnail aside when a `videoId` exists
- update base layout to flex-wrap main content and optional video panel

## Testing
- `node generate_pages.js`

------
https://chatgpt.com/codex/tasks/task_e_68bbc5e717c083258d303a9e580898a5