### PR TITLE
Remove video references

### DIFF
--- a/content/curatedL4.json
+++ b/content/curatedL4.json
@@ -2,7 +2,6 @@
   "Decentralization": {
     "Node Diversity": {
       "blurb": "Many independent operators reduce capture risk.",
-      "videoId": "dQw4w9WgXcQ",
       "sections": {
         "why": "Diverse node operators make censorship or coordinated failure less likely.",
         "key": [

--- a/content/pages.json
+++ b/content/pages.json
@@ -1,7 +1,6 @@
 {
   "title": "Web3",
   "blurb": "A user-empowering internet that encodes trust and value natively using cryptography, blockchains, and open protocols.",
-  "videoId": "M7lc1UVf-VE",
   "children": [
     {
       "title": "Foundations & Principles",
@@ -10,7 +9,6 @@
         {
           "title": "Decentralization",
           "blurb": "Shift of control from single authorities to distributed participants.",
-          "videoId": "hYip_Vuv8J0",
           "children": []
         },
         {

--- a/generate_pages.js
+++ b/generate_pages.js
@@ -17,15 +17,6 @@ function render(values) {
   return html;
 }
 
-function videoHtml(videoId) {
-  if (!videoId) return '';
-  return `<aside class="w-full md:w-80 md:ml-4 mt-4 md:mt-0 shrink-0">
-    <a href="https://youtu.be/${videoId}" target="_blank">
-      <img src="https://img.youtube.com/vi/${videoId}/hqdefault.jpg" alt="YouTube thumbnail" />
-    </a>
-  </aside>`;
-}
-
 function sectionHtml(sections = {}) {
   let html = '';
   if (sections.why) {
@@ -50,7 +41,7 @@ function sectionHtml(sections = {}) {
   return html;
 }
 
-function pageTemplate(title, blurb, linksHtml, depth, backHref, sections = {}, breadcrumbs = '', videoId = '') {
+function pageTemplate(title, blurb, linksHtml, depth, backHref, sections = {}, breadcrumbs = '') {
   const homeHref = depth > 0 ? `${'../'.repeat(depth)}index.html` : 'index.html';
   const rootPrefix = depth > 0 ? '../'.repeat(depth) : '';
   const navLinks = [`<a href="${homeHref}" class="text-blue-200 hover:text-white">Home</a>`];
@@ -62,8 +53,7 @@ function pageTemplate(title, blurb, linksHtml, depth, backHref, sections = {}, b
     sections: sectionHtml(sections),
     nav: navLinks.join('<span>|</span>'),
     rootPrefix,
-    breadcrumbs,
-    video: videoHtml(videoId)
+    breadcrumbs
   });
 }
 
@@ -98,11 +88,11 @@ function generate(node, dir, depth, backHref, ancestors = []) {
   if (l4) {
     links += '<ul>\n';
     if (Array.isArray(l4)) {
-      l4.forEach(([title, blurb, videoId]) => {
+      l4.forEach(([title, blurb]) => {
         const slug = slugify(title);
         links += `  <li><a href="${slug}.html">${title}</a></li>\n`;
         const l4Breadcrumbs = breadcrumbsArr.concat(title).join(' / ');
-        const l4Html = pageTemplate(title, blurb, '', depth, 'index.html', defaultSections(title, blurb), l4Breadcrumbs, videoId);
+        const l4Html = pageTemplate(title, blurb, '', depth, 'index.html', defaultSections(title, blurb), l4Breadcrumbs);
         fs.writeFileSync(path.join(dir, `${slug}.html`), l4Html);
       });
     } else {
@@ -111,13 +101,13 @@ function generate(node, dir, depth, backHref, ancestors = []) {
         links += `  <li><a href="${slug}.html">${title}</a></li>\n`;
         const sections = entry.sections || defaultSections(title, entry.blurb);
         const l4Breadcrumbs = breadcrumbsArr.concat(title).join(' / ');
-        const l4Html = pageTemplate(title, entry.blurb, '', depth, 'index.html', sections, l4Breadcrumbs, entry.videoId);
+        const l4Html = pageTemplate(title, entry.blurb, '', depth, 'index.html', sections, l4Breadcrumbs);
         fs.writeFileSync(path.join(dir, `${slug}.html`), l4Html);
       });
     }
     links += '</ul>\n';
   }
-  const html = pageTemplate(node.title, node.blurb, links, depth, backHref, {}, breadcrumbs, node.videoId);
+  const html = pageTemplate(node.title, node.blurb, links, depth, backHref, {}, breadcrumbs);
   fs.writeFileSync(path.join(dir, 'index.html'), html);
   if (node.children && node.children.length) {
     node.children.forEach(child => {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -30,7 +30,6 @@
         {{links}}
         {{sections}}
       </main>
-      {{video}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- drop all videoId fields from content data
- simplify layout and generator to remove video embeds

## Testing
- `node generate_pages.js`

------
https://chatgpt.com/codex/tasks/task_e_68bbf7459ca88325ab8d5c262c9ff112