### PR TITLE
Move recall button to header and enhance recall cards

### DIFF
--- a/generate_pages.js
+++ b/generate_pages.js
@@ -76,9 +76,6 @@ function generate(node, dir, depth, backHref, ancestors = []) {
   let links = '';
   const breadcrumbsArr = [...ancestors, node.title];
   const breadcrumbs = breadcrumbsArr.join(' / ');
-  if (depth === 0) {
-    links += '<div class="mb-4"><a href="recall.html" class="bg-blue-500 text-white px-4 py-2 rounded">Recall Practice</a></div>';
-  }
   if (node.children && node.children.length) {
     links += '<ul>\n';
     node.children.forEach(child => {

--- a/recall.html
+++ b/recall.html
@@ -9,30 +9,39 @@
     .card { perspective: 1000px; }
     .card-inner { position: relative; width: 100%; height: 100%; transition: transform 0.6s; transform-style: preserve-3d; }
     .card.flipped .card-inner { transform: rotateY(180deg); }
-    .card-front, .card-back { position: absolute; width: 100%; height: 100%; backface-visibility: hidden; display:flex; align-items:center; justify-content:center; padding:1rem; border-radius:0.5rem; box-shadow:0 2px 4px rgba(0,0,0,0.1); background:white; }
+    .card-front, .card-back { position: absolute; width: 100%; height: 100%; backface-visibility: hidden; display:flex; align-items:center; justify-content:center; padding:1rem; border-radius:0.5rem; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
     .card-back { transform: rotateY(180deg); }
   </style>
 </head>
 <body class="bg-gray-50 text-gray-800">
   <header class="bg-gray-800 text-white p-4">
-    <div class="container mx-auto flex justify-between items-center">
-      <nav><a href="index.html" class="text-blue-200 hover:text-white">Home</a></nav>
-      <h1 class="text-xl font-semibold">Recall Practice</h1>
+    <div class="container mx-auto">
+      <div class="flex items-center justify-between">
+        <nav><a href="index.html" class="text-blue-200 hover:text-white">Home</a></nav>
+        <input id="search" type="text" placeholder="Search..." class="text-black px-2 py-1 rounded" />
+      </div>
+      <div class="flex justify-end mt-2">
+        <a href="recall.html" class="bg-blue-500 text-white px-4 py-2 rounded">Recall Practice</a>
+      </div>
+      <h1 class="text-xl font-semibold mt-2">Recall Practice</h1>
     </div>
   </header>
   <main class="container mx-auto p-4">
     <div id="flashcards" class="flex flex-col items-center"></div>
   </main>
   <footer class="bg-gray-100 text-center text-sm text-gray-500 py-4 mt-8">© 2024 Web3 Overview</footer>
+  <script src="search.js"></script>
   <script>
+    const colors = ['bg-blue-100', 'bg-green-100', 'bg-yellow-100', 'bg-pink-100'];
+
     async function load() {
       const res = await fetch('content/pages.json');
       const data = await res.json();
-      const root = createNode(data);
+      const root = createNode(data, 0);
       document.getElementById('flashcards').appendChild(root);
     }
 
-    function createNode(node) {
+    function createNode(node, depth = 0) {
       const wrapper = document.createElement('div');
       wrapper.className = 'flex flex-col items-center';
 
@@ -41,10 +50,10 @@
       const inner = document.createElement('div');
       inner.className = 'card-inner';
       const front = document.createElement('div');
-      front.className = 'card-front text-center';
+      front.className = `card-front text-center ${colors[depth % colors.length]}`;
       front.textContent = node.title;
       const back = document.createElement('div');
-      back.className = 'card-back text-center text-sm';
+      back.className = `card-back text-center text-sm ${colors[depth % colors.length]}`;
       back.textContent = node.blurb;
       inner.appendChild(front);
       inner.appendChild(back);
@@ -57,10 +66,12 @@
         card.classList.toggle('flipped');
         const flipped = card.classList.contains('flipped');
         if (flipped && node.children && node.children.length) {
+          hideSiblingsAndReset(wrapper);
           childrenContainer.classList.remove('hidden');
         } else {
           hideChildren(childrenContainer);
           childrenContainer.classList.add('hidden');
+          showSiblings(wrapper);
         }
       });
 
@@ -68,7 +79,7 @@
       wrapper.appendChild(childrenContainer);
 
       (node.children || []).forEach(child => {
-        childrenContainer.appendChild(createNode(child));
+        childrenContainer.appendChild(createNode(child, depth + 1));
       });
 
       return wrapper;
@@ -77,6 +88,29 @@
     function hideChildren(container) {
       container.querySelectorAll('.card.flipped').forEach(c => c.classList.remove('flipped'));
       container.querySelectorAll('.children-container').forEach(cc => cc.classList.add('hidden'));
+    }
+
+    function hideSiblingsAndReset(element) {
+      const parent = element.parentElement;
+      if (!parent) return;
+      Array.from(parent.children).forEach(child => {
+        if (child !== element) {
+          child.classList.add('hidden');
+          const card = child.querySelector('.card');
+          const container = child.querySelector('.children-container');
+          if (card) card.classList.remove('flipped');
+          if (container) {
+            hideChildren(container);
+            container.classList.add('hidden');
+          }
+        }
+      });
+    }
+
+    function showSiblings(element) {
+      const parent = element.parentElement;
+      if (!parent) return;
+      Array.from(parent.children).forEach(child => child.classList.remove('hidden'));
     }
 
     load();

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -16,6 +16,9 @@
         </div>
         <input id="search" type="text" placeholder="Search..." class="text-black px-2 py-1 rounded" />
       </div>
+      <div class="flex justify-end mt-2">
+        <a href="{{rootPrefix}}recall.html" class="bg-blue-500 text-white px-4 py-2 rounded">Recall Practice</a>
+      </div>
       <h1 class="text-xl font-semibold mt-2">Web 3.0 - Quick Tour</h1>
       <div class="text-sm text-gray-300 mt-1">{{breadcrumbs}}</div>
     </div>


### PR DESCRIPTION
## Summary
- Place "Recall Practice" link beneath the search field in the global header so it appears on every page.
- Color-code recall flashcards with pastel shades by depth and hide sibling cards when expanding a node for focused study.
- Remove obsolete home-page recall link from the page generator and update recall page header to include search and recall link.

## Testing
- `node generate_pages.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc30f2a8708325a6eacc428b9c8b16