### PR TITLE
Show concept title on flashcard back

### DIFF
--- a/recall.html
+++ b/recall.html
@@ -74,8 +74,8 @@
       front.className = `card-front text-center ${colors[depth % colors.length]}`;
       front.textContent = node.title;
       const back = document.createElement('div');
-      back.className = `card-back text-center text-sm ${colors[depth % colors.length]}`;
-      back.textContent = node.blurb;
+      back.className = `card-back flex-col text-center text-sm ${colors[depth % colors.length]}`;
+      back.innerHTML = `<h3 class="font-semibold mb-1">${node.title}</h3><p>${node.blurb}</p>`;
       inner.appendChild(front);
       inner.appendChild(back);
       card.appendChild(inner);


### PR DESCRIPTION
## Summary
- Display flashcard concept title above its explanation on the card's reverse side for clearer context during review.

## Testing
- `npm test` *(fails: could not find a package.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3af58d888325a53e2cfd14b31272