### PR TITLE
Add Docker support with Ollama info panel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY . .
+RUN npm install -g http-server \
+ && node generate_pages.js \
+ && echo 'window.RUNNING_IN_DOCKER = true;' > config.js
+EXPOSE 8080
+CMD ["http-server", ".", "-p", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Web3_Overview
+# Web3 Overview
+
+Static site exploring Web3 topics. Pages are generated from content definitions using `generate_pages.js`.
+
+## Development
+
+```bash
+node generate_pages.js
+```
+
+## Docker
+
+Build the Docker image:
+
+```bash
+docker build -t web3-overview .
+```
+
+Run the container (requires a local Ollama server on port 11434):
+
+```bash
+docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway web3-overview
+```
+
+When running inside Docker, each page queries the local Ollama server for a brief outline of the topic and displays it in the right-hand panel. If the site is not running in Docker, or the server is unreachable, the panel remains empty.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,1 @@
+window.RUNNING_IN_DOCKER = false;

--- a/ollama.js
+++ b/ollama.js
@@ -1,0 +1,29 @@
+window.addEventListener('DOMContentLoaded', async () => {
+  if (!window.RUNNING_IN_DOCKER) return;
+  const container = document.getElementById('ollama-info');
+  const heading = document.querySelector('main h1');
+  if (!container || !heading) return;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch('http://host.docker.internal:11434/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'llama2',
+        prompt: `Provide a brief markdown outline on ${heading.textContent}.`,
+        stream: false
+      }),
+      signal: controller.signal
+    });
+    clearTimeout(timeout);
+    if (!res.ok) return;
+    const data = await res.json();
+    const text = data.response || '';
+    container.classList.add('whitespace-pre-line');
+    container.textContent = text.trim();
+  } catch (err) {
+    // If the request fails or server is unavailable, leave container empty.
+  }
+});

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,17 +27,20 @@
   <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block"></aside>
   <div class="flex-1 p-4">
     <div class="flex flex-col md:flex-row">
-      <main class="flex-1">
+      <main class="flex-1 md:pr-4">
         <h1 class="text-3xl font-bold mb-4">{{title}}</h1>
         <p>{{blurb}}</p>
         {{links}}
         {{sections}}
       </main>
+      <aside id="ollama-info" class="md:w-1/3 md:border-l md:pl-4"></aside>
     </div>
   </div>
 </div>
 <footer class="bg-gray-100 text-center text-sm text-gray-500 py-4 mt-8">© 2024 Web3 Overview</footer>
 <script src="{{rootPrefix}}sidebar.js"></script>
 <script src="{{rootPrefix}}search.js"></script>
+<script src="{{rootPrefix}}config.js"></script>
+<script src="{{rootPrefix}}ollama.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Dockerfile for serving generated site
- fetch Ollama topic summaries in Docker and show in right-hand panel
- document Docker build/run instructions

## Testing
- `node generate_pages.js`
- `docker build -t web3-overview .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bce71f2bb483258751cfd6c0812889