### PR TITLE
Add cache-control headers for static assets

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,14 +1,17 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 8080;
 
 app.get('/', (req, res) => {
   res.set('Content-Type', 'text/html; charset=utf-8');
+  res.set('Cache-Control', 'no-cache');
   res.type('html').sendFile('index.html', { root: __dirname });
 });
 
-app.get(/^.*\.html$/, (req, res, next) => {
+app.get(/^(?!\/templates\/).*\.html$/, (req, res, next) => {
   res.set('Content-Type', 'text/html; charset=utf-8');
+  res.set('Cache-Control', 'no-cache');
   res
     .type('html')
     .sendFile(req.path, { root: __dirname }, err => {
@@ -16,7 +19,19 @@ app.get(/^.*\.html$/, (req, res, next) => {
     });
 });
 
-app.use(express.static(__dirname));
+const setImmutableCache = (res, filePath) => {
+  const ext = path.extname(filePath).toLowerCase();
+  const isImmutable =
+    filePath.includes(`${path.sep}content${path.sep}`) ||
+    filePath.includes(`${path.sep}templates${path.sep}`) ||
+    ext === '.js' ||
+    ext === '.css';
+  if (isImmutable) {
+    res.set('Cache-Control', 'public, max-age=31536000, immutable');
+  }
+};
+
+app.use(express.static(__dirname, { setHeaders: setImmutableCache }));
 
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);


### PR DESCRIPTION
## Summary
- Set long-term immutable caching for `/content`, `/templates`, JS, and CSS assets
- Serve HTML files with `Cache-Control: no-cache`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -I http://localhost:8080/recall.html`
- `curl -I http://localhost:8080/sidebar.js`
- `curl -I http://localhost:8080/content/pages.json`
- `curl -I http://localhost:8080/templates/layout.html`


------
https://chatgpt.com/codex/tasks/task_e_68bd0e9d57888325b1283203f6c5a57b