### PR TITLE
Add X-Content-Type-Options header to Express responses

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,11 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 8080;
 
+app.use((req, res, next) => {
+  res.set('X-Content-Type-Options', 'nosniff');
+  next();
+});
+
 app.get('/', (req, res) => {
   res.set('Content-Type', 'text/html; charset=utf-8');
   res.set('Cache-Control', 'no-cache');


### PR DESCRIPTION
## Summary
- apply middleware that sets `X-Content-Type-Options: nosniff` on every request

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd11de36e88325bf5b9b7e343cc734