### PR TITLE
Decouple Docker detection from client logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN node generate_pages.js \
- && echo 'window.RUNNING_IN_DOCKER = true;' > config.js
+RUN node generate_pages.js
 EXPOSE 8080
 CMD ["node", "server.js"]

--- a/config.js
+++ b/config.js
@@ -1,1 +1,8 @@
-window.RUNNING_IN_DOCKER = false;
+// Allow the runtime to specify whether we are executing in a Docker
+// environment.  This value can be injected at build time via an
+// environment variable or by setting `globalThis.RUNNING_IN_DOCKER`
+// before this script loads.  It defaults to `false` when not provided.
+window.RUNNING_IN_DOCKER = !!(
+  (typeof process !== 'undefined' && process.env.RUNNING_IN_DOCKER === 'true') ||
+  globalThis.RUNNING_IN_DOCKER
+);

--- a/ollama.js
+++ b/ollama.js
@@ -1,5 +1,4 @@
 window.addEventListener('DOMContentLoaded', async () => {
-  if (!window.RUNNING_IN_DOCKER) return;
   const container = document.getElementById('ollama-info');
   const heading = document.querySelector('main h1');
   if (!container || !heading) return;


### PR DESCRIPTION
## Summary
- allow Docker detection to be configured via environment variable or global flag
- always execute Ollama helper regardless of Docker context
- remove Dockerfile step that rewrote config.js

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1d2390c883259a34c98a2d757691