### PR TITLE
Render Ollama responses as formatted Markdown

### DIFF
--- a/ollama.js
+++ b/ollama.js
@@ -20,8 +20,13 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (!res.ok) return;
     const data = await res.json();
     const text = data.response || '';
-    container.classList.add('whitespace-pre-line');
-    container.textContent = text.trim();
+
+    try {
+      const { marked } = await import('https://cdn.jsdelivr.net/npm/marked@11.2.0/marked.esm.js');
+      container.innerHTML = marked.parse(text.trim());
+    } catch {
+      container.textContent = text.trim();
+    }
   } catch (err) {
     // If the request fails or server is unavailable, leave container empty.
   }


### PR DESCRIPTION
## Summary
- convert fetched Markdown into HTML using marked and render via innerHTML

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1e5629f08325bee867351db21c08