### PR TITLE
Reset nested card visibility when returning to higher levels

### DIFF
--- a/recall.html
+++ b/recall.html
@@ -155,8 +155,12 @@
 
     function hideChildren(container) {
       container.querySelectorAll('.card.flipped').forEach(c => c.classList.remove('flipped'));
-      container.querySelectorAll('.children-container').forEach(cc => cc.classList.add('hidden'));
-      container.querySelectorAll('.detail-container').forEach(dc => dc.classList.add('hidden'));
+      container.querySelectorAll(':scope > div > .children-container').forEach(cc => {
+        hideChildren(cc);
+        cc.classList.add('hidden');
+      });
+      container.querySelectorAll(':scope > div > .detail-container').forEach(dc => dc.classList.add('hidden'));
+      Array.from(container.children).forEach(child => child.classList.remove('hidden'));
     }
 
     function hideSiblingsAndReset(element) {


### PR DESCRIPTION
## Summary
- Reset hidden state of nested flashcards when closing a concept
- Recursively clear flipped and detail panels so reopening a higher level shows all children

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68be8eab58dc8325b50f2ffed912e832