### PR TITLE
Allow configurable model for Ollama

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:18-alpine
 WORKDIR /app
+ENV OLLAMA_MODEL=llama3.2
 COPY package*.json ./
 RUN npm install
 COPY . .

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docker build -t web3-overview .
 Run the container (requires a local Ollama server on port 11434):
 
 ```bash
-docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway web3-overview
+docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway -e OLLAMA_MODEL=<model> web3-overview
 ```
 
 When running inside Docker, each page queries the local Ollama server for a brief outline of the topic and displays it in the right-hand panel. If the site is not running in Docker, or the server is unreachable, the panel remains empty.

--- a/server.js
+++ b/server.js
@@ -21,7 +21,12 @@ app.get('/', (req, res) => {
 });
 
 app.post('/ask', async (req, res) => {
-  const { prompt, temperature, max_tokens } = req.body;
+  const {
+    model = process.env.OLLAMA_MODEL || 'llama3.2',
+    prompt,
+    temperature,
+    max_tokens,
+  } = req.body;
   const baseUrl =
     process.env.OLLAMA_BASE_URL || 'http://host.docker.internal:11434';
   try {
@@ -29,12 +34,12 @@ app.post('/ask', async (req, res) => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'llama3.2',
+        model,
         prompt,
         temperature,
         max_tokens,
-        stream: false
-      })
+        stream: false,
+      }),
     });
     const data = await response.json();
     res.json(data);


### PR DESCRIPTION
## Summary
- Allow server to choose model via request body or OLLAMA_MODEL env variable
- Document how to pass model to Docker container
- Default OLLAMA_MODEL to llama3.2 in Docker image

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf041f976883259013bfa0868e746d