### PR TITLE
Fix knowledge graph visibility

### DIFF
--- a/knowledge-graph.html
+++ b/knowledge-graph.html
@@ -31,7 +31,7 @@
         <main class="flex-1 md:pr-4">
           <h1 class="text-3xl font-bold mb-4">Knowledge Graph</h1>
           <div class="overflow-x-auto">
-            <svg id="graph" class="min-w-[1200px] w-full h-[600px]"></svg>
+            <svg id="graph" class="min-w-[1600px] w-full h-[800px] bg-white"></svg>
           </div>
         </main>
         <aside id="ollama-info" class="md:w-1/3 md:border-l md:pl-4"></aside>

--- a/knowledge-graph.js
+++ b/knowledge-graph.js
@@ -15,8 +15,8 @@
   }
   traverse(data);
 
-  const width = 1200;
-  const height = 600;
+  const width = 1600;
+  const height = 800;
   const svg = d3.select('#graph').attr('viewBox', [0, 0, width, height]);
 
   const simulation = d3.forceSimulation(nodes)
@@ -33,8 +33,6 @@
     .attr('stroke-width', 1.5);
 
   const node = svg.append('g')
-    .attr('stroke', '#fff')
-    .attr('stroke-width', 1.5)
     .selectAll('g')
     .data(nodes)
     .join('g')
@@ -45,13 +43,16 @@
 
   node.append('circle')
     .attr('r', 10)
-    .attr('fill', '#3b82f6');
+    .attr('fill', '#3b82f6')
+    .attr('stroke', '#fff')
+    .attr('stroke-width', 1.5);
 
   node.append('text')
     .text(d => d.id)
     .attr('x', 12)
     .attr('y', '0.31em')
-    .attr('fill', '#000');
+    .attr('fill', '#000')
+    .attr('stroke', 'none');
 
   simulation.on('tick', () => {
     link


### PR DESCRIPTION
## Summary
- Move node stroke styling to circles so text labels render in black

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c14aa9c2088325b07a0542d3d9bcaf