### PR TITLE
style: set knowledge graph labels to blue

### DIFF
--- a/knowledge-graph.html
+++ b/knowledge-graph.html
@@ -8,6 +8,7 @@
   <script src="https://d3js.org/d3.v7.min.js"></script>
   <style>
     html { text-size-adjust: 100%; }
+    #graph text { fill: #1e40af; }
   </style>
 </head>
 <body class="bg-gray-50 text-gray-800">

--- a/knowledge-graph.js
+++ b/knowledge-graph.js
@@ -51,7 +51,7 @@
     .text(d => d.id)
     .attr('x', 12)
     .attr('y', '0.31em')
-    .attr('fill', '#000')
+    .attr('fill', '#1e40af')
     .attr('stroke', 'none');
 
   simulation.on('tick', () => {


### PR DESCRIPTION
## Summary
- ensure knowledge graph node labels use a visible blue color
- enforce text color via inline SVG style for consistency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c14d6a227c8325a663d6c8a463f44b