### PR TITLE
feat: make sidebars resizable

### DIFF
--- a/knowledge-graph.html
+++ b/knowledge-graph.html
@@ -26,7 +26,8 @@
     </div>
   </header>
   <div class="container mx-auto flex">
-    <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block"></aside>
+    <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block flex-shrink-0 overflow-auto"></aside>
+    <div id="sidebar-resizer" class="hidden md:block w-1 bg-gray-300 cursor-col-resize flex-shrink-0"></div>
     <div class="flex-1 p-4">
       <div class="flex flex-col md:flex-row">
         <main class="flex-1 md:pr-4">
@@ -35,7 +36,8 @@
             <svg id="graph" class="min-w-[1600px] w-full h-[800px] bg-white"></svg>
           </div>
         </main>
-        <aside id="ollama-info" class="md:w-1/3 md:border-l md:pl-4"></aside>
+        <div id="ollama-resizer" class="hidden md:block w-1 bg-gray-300 cursor-col-resize flex-shrink-0"></div>
+        <aside id="ollama-info" class="md:w-1/3 md:pl-4 flex-shrink-0 overflow-auto"></aside>
       </div>
     </div>
   </div>
@@ -44,6 +46,7 @@
   <script src="search.js"></script>
   <script src="config.js"></script>
   <script src="ollama.js"></script>
+  <script src="resizable.js"></script>
   <script src="knowledge-graph.js"></script>
 </body>
 </html>

--- a/resizable.js
+++ b/resizable.js
@@ -1,0 +1,29 @@
+(function() {
+  function initResizable(sidebar, resizer, direction) {
+    if (!sidebar || !resizer) return;
+    let startX, startWidth;
+    const minWidth = 150;
+    resizer.addEventListener('mousedown', function(e) {
+      e.preventDefault();
+      startX = e.clientX;
+      startWidth = parseInt(getComputedStyle(sidebar).width, 10);
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', stopResize);
+    });
+    function onMouseMove(e) {
+      let newWidth = direction === 'right'
+        ? startWidth + (e.clientX - startX)
+        : startWidth + (startX - e.clientX);
+      if (newWidth < minWidth) newWidth = minWidth;
+      sidebar.style.width = newWidth + 'px';
+    }
+    function stopResize() {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', stopResize);
+    }
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    initResizable(document.getElementById('sidebar'), document.getElementById('sidebar-resizer'), 'right');
+    initResizable(document.getElementById('ollama-info'), document.getElementById('ollama-resizer'), 'left');
+  });
+})();

--- a/sidebar.js
+++ b/sidebar.js
@@ -5,9 +5,11 @@ window.addEventListener('DOMContentLoaded', async () => {
   const rootPrefix = '../'.repeat(depth);
   const sidebar = document.getElementById('sidebar');
   const toggleButton = document.getElementById('sidebarToggle');
+  const sidebarResizer = document.getElementById('sidebar-resizer');
   if (toggleButton) {
     toggleButton.addEventListener('click', () => {
       if (sidebar) sidebar.classList.toggle('hidden');
+      if (sidebarResizer) sidebarResizer.classList.toggle('hidden');
     });
   }
   if (!sidebar) return;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -28,7 +28,8 @@
     </div>
   </header>
 <div class="container mx-auto flex">
-  <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block"></aside>
+  <aside id="sidebar" class="w-64 bg-gray-100 p-4 hidden md:block flex-shrink-0 overflow-auto"></aside>
+  <div id="sidebar-resizer" class="hidden md:block w-1 bg-gray-300 cursor-col-resize flex-shrink-0"></div>
   <div class="flex-1 p-4">
     <div class="flex flex-col md:flex-row">
       <main class="flex-1 md:pr-4">
@@ -37,7 +38,8 @@
         {{links}}
         {{sections}}
       </main>
-      <aside id="ollama-info" class="md:w-1/3 md:border-l md:pl-4"></aside>
+      <div id="ollama-resizer" class="hidden md:block w-1 bg-gray-300 cursor-col-resize flex-shrink-0"></div>
+      <aside id="ollama-info" class="md:w-1/3 md:pl-4 flex-shrink-0 overflow-auto"></aside>
     </div>
   </div>
 </div>
@@ -46,5 +48,6 @@
 <script src="{{rootPrefix}}search.js"></script>
 <script src="{{rootPrefix}}config.js"></script>
 <script src="{{rootPrefix}}ollama.js"></script>
+<script src="{{rootPrefix}}resizable.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add resizable handles for left navigation and right AI asides
- add script enabling draggable width adjustments
- keep resizer hidden when sidebar is toggled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c15f8f841483259c97411fe8ef0d6b